### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Run and deploy large language models locally or in the cloud.
 - **[gpt4free](https://github.com/xtekky/gpt4free)** - Various collection of powerful language models. ![Stars](https://img.shields.io/github/stars/xtekky/gpt4free?style=flat-square)
 
 ## AI Agents & Autonomous Systems
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - Solana-native x402 MCP server for AI agent trust scoring. Free: `score_agent`, `preflight_check`. Paid: signed trust receipt via HTTP 402 + USDC on Solana.
 
 Autonomous agents that can perform tasks, research, and make decisions.
 


### PR DESCRIPTION
## Summary

Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** to the list.

**TWZRD Agent Intel** is a Solana-native trust scoring MCP server for AI agents:
- **MCP endpoint**: streamable-HTTP at `https://intel.twzrd.xyz/mcp`
- **Free tools**: `score_agent(wallet)`, `preflight_check(wallet)` — Solana wallet trust scores
- **Paid tool**: `get_trust_receipt(wallet)` — signed trust receipt via HTTP 402 + USDC micropayment on Solana
- **Config**: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`

This is the only x402 MCP server with Solana-native trust scoring and on-chain payment receipts.