### PR TITLE
feat: add NotFair - Claude Code agent skills for SEO and paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Autonomous agents that can perform tasks, research, and make decisions.
 - **[gpt-researcher](https://github.com/assafelovic/gpt-researcher)** - Autonomous agent that conducts web research and generates comprehensive reports with citations. ![Stars](https://img.shields.io/github/stars/assafelovic/gpt-researcher?style=flat-square)
 - **[storm](https://github.com/stanford-oval/storm)** - LLM-powered knowledge curation system that researches topics and generates full reports. ![Stars](https://img.shields.io/github/stars/stanford-oval/storm?style=flat-square)
 - **[plandex](https://github.com/plandex-ai/plandex)** - AI driven development in your terminal. Designed for large, real-world tasks. ![Stars](https://img.shields.io/github/stars/plandex-ai/plandex?style=flat-square)
+- **[NotFair](https://github.com/nowork-studio/NotFair)** - Open-source Claude Code agent skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. ![Stars](https://img.shields.io/github/stars/nowork-studio/NotFair?style=flat-square)
 
 ## AI Assistants & Chatbots
 


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** — an open-source set of Claude Code agent skills for marketing work (SEO, Google Ads, and Meta Ads). It has ~2.9k stars on GitHub and is MIT licensed.

It connects to live account data through four MCPs: Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. The skills cover site audits, keyword research, meta tags and schema markup, wasted-spend detection, and Meta (Facebook/Instagram) ROAS analysis, among others.

I placed it in the "AI Agents & Autonomous Systems" section since it's a set of autonomous agent skills. Happy to move it to "Specialized AI Tools" or reword the description if that works better for you. Thanks for taking a look!