### PR TITLE
Add Orkas to AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Autonomous agents that can perform tasks, research, and make decisions.
 - **[storm](https://github.com/stanford-oval/storm)** - LLM-powered knowledge curation system that researches topics and generates full reports. ![Stars](https://img.shields.io/github/stars/stanford-oval/storm?style=flat-square)
 - **[plandex](https://github.com/plandex-ai/plandex)** - AI driven development in your terminal. Designed for large, real-world tasks. ![Stars](https://img.shields.io/github/stars/plandex-ai/plandex?style=flat-square)
 - **[NotFair](https://github.com/nowork-studio/NotFair)** - Open-source Claude Code agent skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. ![Stars](https://img.shields.io/github/stars/nowork-studio/NotFair?style=flat-square)
+- **[Orkas](https://orkas.ai?source=gh-jmc)** - Open-source, local-first desktop AI workforce where a Commander coordinates specialist agents in parallel or sequence. [Source](https://github.com/Orkas-AI/Orkas) ![Stars](https://img.shields.io/github/stars/Orkas-AI/Orkas?style=flat-square)
 
 ## AI Assistants & Chatbots
 


### PR DESCRIPTION
## Summary
- add Orkas to the AI Agents & Autonomous Systems section
- link the official website with a distinct source tag and the MIT-licensed repository

## Why it fits
Orkas is an open-source, local-first desktop AI workforce. A Commander coordinates specialist agents in parallel or sequence through one chat, and users bring their own model keys.

## Verification
- Official site: https://orkas.ai?source=gh-jmc
- Source: https://github.com/Orkas-AI/Orkas