### PR TITLE
Add Orkas source repository

### DIFF
--- a/urls.txt
+++ b/urls.txt
@@ -103,3 +103,4 @@ https://github.com/pranauv1/AI-Video-Translation
 https://github.com/THU-MIG/yolov10
 https://github.com/FunAudioLLM/CosyVoice
 https://github.com/sipeed/picoclaw
+https://github.com/Orkas-AI/Orkas


### PR DESCRIPTION
## Summary
- add the Orkas source repository to `urls.txt`
- let the repository generator fetch its metadata and place it in the appropriate category

## Verification
- Source: https://github.com/Orkas-AI/Orkas
- MIT licensed and above the 50-star requirement