### PR TITLE
Add GPT Image 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Text-to-image generation and diffusion models.
 - **[ComfyUI](https://github.com/Comfy-Org/ComfyUI)** - The most powerful and modular diffusion model GUI with a graph/nodes interface. ![Stars](https://img.shields.io/github/stars/Comfy-Org/ComfyUI?style=flat-square)
 - **[Janus](https://github.com/deepseek-ai/Janus)** - Unified Multimodal Understanding and Generation Models. ![Stars](https://img.shields.io/github/stars/deepseek-ai/Janus?style=flat-square)
 - **[DiffSynth-Studio](https://github.com/modelscope/DiffSynth-Studio)** - Enjoy the magic of Diffusion models! ![Stars](https://img.shields.io/github/stars/modelscope/DiffSynth-Studio?style=flat-square)
+- **[GPT Image 2](https://gptimage2.asia)** - AI image generation and editing for marketing, ecommerce, social media, and branded content. ![Stars](https://img.shields.io/github/stars/xianyu110/gptimage2.asia?style=flat-square)
 
 ## Image Enhancement
 


### PR DESCRIPTION
## Summary
Adds GPT Image 2 to the Image Generation section.

Added entry:

- **[GPT Image 2](https://gptimage2.asia)** - AI image generation and editing for marketing, ecommerce, social media, and branded content.

Disclosure: submitted by the project owner/operator.